### PR TITLE
fix: move app definition to commands to fix current error in cli

### DIFF
--- a/src/n8nmermaid/cli/commands.py
+++ b/src/n8nmermaid/cli/commands.py
@@ -13,6 +13,7 @@ from n8nmermaid.models_v2.request_v2_models import (
     MermaidGenerationParamsV2,
     ReportGenerationParamsV2,
 )
+from n8nmermaid.utils.logging import setup_logging
 
 from .enums import (
     CliMermaidDirection,
@@ -21,8 +22,18 @@ from .enums import (
     CliSubgraphDisplayMode,
 )
 from .helpers import run_orchestration_v2
-from .main import app
 
+app = typer.Typer(
+    name="n8nmermaid",
+    help="Analyzes n8n workflow JSON files and generates Mermaid diagrams or reports.",
+    add_completion=False,
+)
+
+
+@app.callback()
+def main_callback():
+    """Main entry point setup. Called before any command. Configures logging."""
+    setup_logging()
 
 @app.command("mermaid")
 def generate_mermaid_diagram_v2(

--- a/src/n8nmermaid/cli/main.py
+++ b/src/n8nmermaid/cli/main.py
@@ -1,23 +1,11 @@
 # src/n8nmermaid/cli/main.py
 """Main CLI application definition using Typer."""
 
-import typer
-
-from n8nmermaid.utils.logging import setup_logging
-
-app = typer.Typer(
-    name="n8nmermaid",
-    help="Analyzes n8n workflow JSON files and generates Mermaid diagrams or reports.",
-    add_completion=False,
-)
+from n8nmermaid.cli.commands import app
 
 
-@app.callback()
-def main_callback():
-    """Main entry point setup. Called before any command. Configures logging."""
-    setup_logging()
-
-
+def main():
+    app()
 
 if __name__ == "__main__":
-    app()
+    main()


### PR DESCRIPTION
This PR aims to fix the error mentioned here: https://github.com/jwa91/n8nmermaid/issues/1#issue-3145738409

In `src/n8nmermaid/cli/main.py`, you don't import anything from `src/n8nmermaid/cli/commands.py`. Since Python is an interpreted language, this means nothing from the `commands` module is going to be registered at runtime.

Here I move the `app` instantiation to `commands` and then import it back to main to make it work.